### PR TITLE
make headerParam ignore case, add singular header builder for httpclient

### DIFF
--- a/src/main/java/com/jinyframework/HttpClient.java
+++ b/src/main/java/com/jinyframework/HttpClient.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public final class HttpClient {
     private final String url;
     private final String method;
+    @Singular
     private final Map<String, String> headers;
     private final String body;
 

--- a/src/main/java/com/jinyframework/core/AbstractRequestBinder.java
+++ b/src/main/java/com/jinyframework/core/AbstractRequestBinder.java
@@ -111,7 +111,7 @@ public abstract class AbstractRequestBinder<T extends HandlerBase> {
         private final Map<String, String> responseHeaders;
 
         public String headerParam(@NonNull final String name) {
-            return header.get(name) != null ? header.get(name) : "";
+            return header.get(name.toLowerCase()) != null ? header.get(name.toLowerCase()) : "";
         }
 
         public String pathParam(@NonNull final String name) {

--- a/src/test/java/com/jinyframework/HTTPServerTest.java
+++ b/src/test/java/com/jinyframework/HTTPServerTest.java
@@ -31,6 +31,8 @@ public class HTTPServerTest extends HTTPTest {
             server.get("/gm", ctx -> HttpResponse.of(ctx.dataParam("global")));
             server.get("/gm-sub", ctx -> HttpResponse.of(ctx.dataParam("att")));
             server.post("/echo", ctx -> HttpResponse.of(ctx.getBody()));
+            server.get("/req-header", ctx -> HttpResponse.of(ctx.headerParam("foo")
+                                                             + ctx.headerParam("Bar")));
             server.get("/header", ctx -> {
                 ctx.putHeader("foo", "bar");
                 return HttpResponse.of("Done!");

--- a/src/test/java/com/jinyframework/HTTPTest.java
+++ b/src/test/java/com/jinyframework/HTTPTest.java
@@ -56,6 +56,16 @@ public abstract class HTTPTest {
     }
 
     @Test
+    @DisplayName("Header Params")
+    void headerParams() throws  IOException {
+        val res = HttpClient.builder()
+                .url(url + "/req-header").method("GET")
+                .header("Foo","foo").header("Bar", "bar")
+                .build().perform();
+        assertEquals(res.getBody(),"foobar");
+    }
+
+    @Test
     @DisplayName("Query Params")
     void queryParams() throws IOException {
         val res = HttpClient.builder()

--- a/src/test/java/com/jinyframework/NIOHTTPServerTest.java
+++ b/src/test/java/com/jinyframework/NIOHTTPServerTest.java
@@ -31,6 +31,8 @@ public class NIOHTTPServerTest extends HTTPTest {
             server.get("/gm", ctx -> HttpResponse.ofAsync(ctx.dataParam("global")));
             server.get("/gm-sub", ctx -> HttpResponse.ofAsync(ctx.dataParam("att")));
             server.post("/echo", ctx -> HttpResponse.ofAsync(ctx.getBody()));
+            server.get("/req-header", ctx -> HttpResponse.ofAsync(ctx.headerParam("foo")
+                                                             + ctx.headerParam("Bar")));
             server.get("/header", ctx -> {
                 ctx.putHeader("foo", "bar");
                 return HttpResponse.ofAsync("Done!");


### PR DESCRIPTION
#9 
- fix headerParam only 
- add headerParam test
- add singular annotation for headers