### PR TITLE
Improve: Handle core exceptions internally

### DIFF
--- a/core/src/main/java/com/jinyframework/HttpServer.java
+++ b/core/src/main/java/com/jinyframework/HttpServer.java
@@ -77,29 +77,33 @@ public final class HttpServer extends AbstractHttpRouter<Handler> {
 
     /**
      * Start.
-     *
-     * @throws IOException the io exception
      */
-    public void start() throws IOException {
+    public void start() {
         Intro.begin();
-        serverSocket = new ServerSocket();
-        serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort));
-        log.info("Started Jiny HTTP Server on port " + serverPort);
-        while (!Thread.interrupted()) {
-            val clientSocket = serverSocket.accept();
-            executor.execute(
-                    new RequestPipeline(clientSocket, middlewares, handlers, responseHeaders, transformer));
+        try {
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort));
+            log.info("Started Jiny HTTP Server on port " + serverPort);
+            while (!Thread.interrupted()) {
+                val clientSocket = serverSocket.accept();
+                executor.execute(
+                        new RequestPipeline(clientSocket, middlewares, handlers, responseHeaders, transformer));
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
         }
     }
 
     /**
      * Stop.
-     *
-     * @throws IOException the io exception
      */
-    public void stop() throws IOException {
+    public void stop() {
         if (!serverSocket.isClosed()) {
-            serverSocket.close();
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+                log.error(e.getMessage(), e);
+            }
             log.info("Stopped Jiny HTTP Server on port " + serverPort);
         }
     }

--- a/core/src/test/java/com/jinyframework/HTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/HTTPServerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -79,11 +78,7 @@ public class HTTPServerTest extends HTTPTest {
             catRouter.get("/:foo/:bar", ctx -> HttpResponse.of(ctx.pathParam("foo") + ":" + ctx.pathParam("bar")));
             server.use("/cat", catRouter);
 
-            try {
-                server.start();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            server.start();
         }).start();
 
         // Wait for server to start
@@ -91,7 +86,7 @@ public class HTTPServerTest extends HTTPTest {
     }
 
     @AfterAll
-    static void stopServer() throws IOException {
+    static void stopServer() {
         server.stop();
     }
 }

--- a/core/src/test/java/com/jinyframework/HttpProxyTest.java
+++ b/core/src/test/java/com/jinyframework/HttpProxyTest.java
@@ -24,35 +24,17 @@ public class HttpProxyTest {
     static void startProxy() throws InterruptedException {
         val serverBIO = HttpServer.port(1111);
         serverBIO.get("/hello", ctx -> HttpResponse.of("Hello World"));
-        new Thread(() -> {
-            try {
-                serverBIO.start();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }).start();
+        new Thread(serverBIO::start).start();
 
         val serverNIO = NIOHttpServer.port(2222);
         serverNIO.get("/bye", ctx -> HttpResponse.ofAsync("Bye"));
         serverNIO.post("/echo", ctx -> HttpResponse.ofAsync(ctx.getBody()));
-        new Thread(() -> {
-            try {
-                serverNIO.start();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }).start();
+        new Thread(serverNIO::start).start();
 
         val proxy = HttpProxy.port(8000);
         proxy.use("/bio", "localhost:1111");
         proxy.use("/nio", "localhost:2222");
-        new Thread(() -> {
-            try {
-                proxy.start();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }).start();
+        new Thread(proxy::start).start();
 
         // Wait for server to start
         TimeUnit.SECONDS.sleep(1);

--- a/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -79,11 +78,7 @@ public class NIOHTTPServerTest extends HTTPTest {
             catRouter.get("/:foo/:bar", ctx -> HttpResponse.ofAsync(ctx.pathParam("foo") + ":" + ctx.pathParam("bar")));
             server.use("/cat", catRouter);
 
-            try {
-                server.start();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            server.start();
         }).start();
 
         // Wait for server to start
@@ -91,7 +86,7 @@ public class NIOHTTPServerTest extends HTTPTest {
     }
 
     @AfterAll
-    static void stopServer() throws IOException {
+    static void stopServer() {
         server.stop();
     }
 }


### PR DESCRIPTION
- Remove the `throws IOException` signature of the `start` methods